### PR TITLE
feat: Add functionality to GetList

### DIFF
--- a/src/Functions/Common/GetList.ts
+++ b/src/Functions/Common/GetList.ts
@@ -22,6 +22,19 @@ import AbstractFunction from "../AbstractFunction";
 
 export default class GetList extends AbstractFunction {
   public object: string;
+  /** Maximum number of items to return. */
+  public maxitems?: number;
+  /** List of fields to return in the response. */
+  public fields?: string[];
+  /** First item from total result set to include in response, zero-based integer. */
+  public start?: number;
+  /** Show entity private records if running this at top level. */
+  public showprivate?: boolean;
+  // TODO: write filter property on GetList
+  /** Limits the objects to return based on their field values. */
+  // public filter?: unknown;
+  /** Sorts the objects to return based on their field values. */
+  public sorts?: Array<Record<string, "asc" | "desc">>;
 
   public writeXml(xml: IaXmlWriter): void {
     xml.writeStartElement("function");
@@ -29,6 +42,45 @@ export default class GetList extends AbstractFunction {
 
     xml.writeStartElement("get_list");
     xml.writeAttribute("object", this.object);
+
+    if (this.maxitems != null) {
+      // The API supports a negative maxitem, so no validation performed
+      xml.writeAttribute("maxitems", this.maxitems);
+    }
+
+    if (this.start != null) {
+      // The API supports a negative start, so no validation performed
+      xml.writeAttribute("start", this.start);
+    }
+
+    if (this.showprivate != null) {
+      xml.writeAttribute("showprivate", this.showprivate);
+    }
+
+    // TODO: filter
+
+    if (this.fields != null && this.fields.length > 0) {
+      xml.writeStartElement("fields");
+      for (const field of this.fields) {
+        xml.writeElement("field", field, false);
+      }
+      xml.writeEndElement(); // fields
+    }
+
+    if (this.sorts != null && this.sorts.length > 0) {
+      xml.writeStartElement("sorts");
+      for (const sort of this.sorts) {
+        for (const field in sort) {
+          if (sort.hasOwnProperty(field)) {
+            xml.writeStartElement("sortfield");
+            xml.writeAttribute("order", sort[field]);
+            xml.writeText(field);
+            xml.writeEndElement(); // sortfield
+          }
+        }
+      }
+      xml.writeEndElement(); // sorts
+    }
 
     xml.writeEndElement(); // get_list
 

--- a/src/Xml/IaXmlWriter.ts
+++ b/src/Xml/IaXmlWriter.ts
@@ -166,6 +166,10 @@ export default class IaXmlWriter {
         this.writeElement("day", dateFormat(date, "dd"), writeNull);
     }
 
+    public writeText(value: string): void {
+        this._writer = this._writer.text(value);
+    }
+
     public writeCustomFieldsExplicit(customFields: Array<[string, any]>) {
         if (customFields != null && customFields.length > 0) {
             this.writeStartElement("customfields");

--- a/test/Functions/Common/GetListTest.ts
+++ b/test/Functions/Common/GetListTest.ts
@@ -13,23 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import * as chai from "chai";
 import GetList from "../../../src/Functions/Common/GetList";
 import XmlObjectTestHelper from "../../Xml/XmlObjectTestHelper";
 
 describe("GetList", () => {
-  before(done => {
-    return done();
-  });
-  beforeEach(done => {
-    return done();
-  });
-  afterEach(done => {
-    return done();
-  });
-  after(done => {
-    return done();
-  });
   it("should get company info", () => {
     const expected = `<?xml version="1.0" encoding="utf-8" ?>
 <test>
@@ -40,6 +27,33 @@ describe("GetList", () => {
 
     const record = new GetList("unittest");
     record.object = "company_info";
+
+    XmlObjectTestHelper.CompareXml(expected, record);
+  });
+  it("should get attachment with all attributes", () => {
+    const expected = `<?xml version="1.0" encoding="utf-8" ?>
+<test>
+    <function controlid="unittest">
+        <get_list object="supdoc" maxitems="1" start="10" showprivate="true">
+            <fields>
+                <field>recordno</field>
+                <field>supdocid</field>
+            </fields>
+            <sorts>
+                <sortfield order="asc">recordno</sortfield>
+                <sortfield order="desc">supdocid</sortfield>
+            </sorts>
+        </get_list>
+    </function>
+</test>`;
+
+    const record = new GetList("unittest");
+    record.object = "supdoc";
+    record.maxitems = 1;
+    record.start = 10;
+    record.showprivate = true;
+    record.fields = ["recordno", "supdocid"];
+    record.sorts = [{ recordno: "asc" }, { supdocid: "desc" }];
 
     XmlObjectTestHelper.CompareXml(expected, record);
   });


### PR DESCRIPTION
Adds all supported functionality to the GetList operator for at least the list attachments API except for filtering, which I was not able to figure out for the time being.