### PR TITLE
feat: Add support for x-sage-app-id header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intacct-thyme/intacct-sdk",
-  "version": "2.2.2-fork.0",
+  "version": "2.2.2-fork.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@intacct-thyme/intacct-sdk",
-      "version": "2.2.2-fork.0",
+      "version": "2.2.2-fork.1",
       "license": "Apache-2.0",
       "dependencies": {
         "content-type": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intacct-thyme/intacct-sdk",
-  "version": "2.2.2-fork.1",
+  "version": "2.2.2-fork.2",
   "description": "Sage Intacct SDK for JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/AbstractClient.ts
+++ b/src/AbstractClient.ts
@@ -34,6 +34,8 @@ export default abstract class AbstractClient {
      */
     protected static readonly PROFILE_ENV_NAME = "INTACCT_PROFILE";
 
+    protected static readonly SAGE_APP_ID_ENV_NAME = "INTACCT_SAGE_APP_ID";
+
     /**
      * @return ClientConfig
      */
@@ -49,6 +51,10 @@ export default abstract class AbstractClient {
 
         if (config.profileName == null) {
             config.profileName = process.env[AbstractClient.PROFILE_ENV_NAME];
+        }
+
+        if (config.sageAppId == null) {
+            config.sageAppId = process.env[AbstractClient.SAGE_APP_ID_ENV_NAME];
         }
 
         if (

--- a/src/ClientConfig.ts
+++ b/src/ClientConfig.ts
@@ -55,6 +55,8 @@ export default class ClientConfig {
 
     public logMessageFormatter: MessageFormatter;
 
+    public sageAppId: string;
+
     constructor() {
         this.logLevel = "debug";
         this.logMessageFormatter = new MessageFormatter();

--- a/src/Xml/RequestHandler.ts
+++ b/src/Xml/RequestHandler.ts
@@ -39,6 +39,7 @@ export default class RequestHandler {
     public requestConfig: RequestConfig;
 
     public endpointUrl: string;
+    public sageAppId: string;
 
     constructor(clientConfig: ClientConfig, requestConfig: RequestConfig) {
         const packageInfo = require("../../package.json");
@@ -50,6 +51,7 @@ export default class RequestHandler {
             const endpoint = new Endpoint(clientConfig);
             this.endpointUrl = endpoint.url;
         }
+        this.sageAppId = clientConfig.sageAppId != null ? clientConfig.sageAppId : "";
         this.clientConfig = clientConfig;
 
         this.requestConfig = requestConfig;
@@ -103,6 +105,12 @@ export default class RequestHandler {
     }
 
     private async execute(xml: string): Promise<string> {
+        const additionalHeaders =
+            this.sageAppId != null && this.sageAppId !== ""
+                ? {
+                    "x-sage-app-id": this.sageAppId,
+                    }
+                : {};
         const httpClient = this.getHttpClient({
             url: this.endpointUrl,
             method: "POST",
@@ -115,6 +123,7 @@ export default class RequestHandler {
                 "Content-Type": "application/xml",
                 "Accept-Encoding": "gzip",
                 "User-Agent": "intacct-sdk-js-client/" + this.version,
+                ...additionalHeaders,
             },
             size: 0,
         });


### PR DESCRIPTION
Sandboxes can be exposed to the public with the protection of an `x-sage-app-id` header.

This PR adds support for setting an x-sage-app-id header both from the environment variable `INTACCT_SAGE_APP_ID` as well as `ClientConfig.sageAppId`.